### PR TITLE
Add kwargs to notification manager's create method and expose context.

### DIFF
--- a/example/tests/test_models.py
+++ b/example/tests/test_models.py
@@ -109,23 +109,26 @@ class NotificationTestCase(TestCase):
         self.assertEqual(self.notification.text, 'James created a new article named The King Of The Cats.')
 
     def test_context_should_contain_related_objects(self):
-        self.assertEqual(self.notification._context, {'article': self.article, 'random_user': self.random_user})
+        self.assertEqual(
+            self.notification.related_objects_dict,
+            {'article': self.article, 'random_user': self.random_user}
+        )
 
     def test_context_should_be_cached(self):
         # force context to load
-        self.notification._context
+        self.notification.related_objects_dict
         self.random_user.username = 'Mr.Random2'
         self.random_user.save()
 
-        self.assertEqual(self.notification._context['random_user'].username, 'Mr.Random')
+        self.assertEqual(self.notification.related_objects_dict['random_user'].username, 'Mr.Random')
 
         self.notification.refresh_from_db()
-        self.assertEqual(self.notification._context['random_user'].username, 'Mr.Random2')
+        self.assertEqual(self.notification.related_objects_dict['random_user'].username, 'Mr.Random2')
 
     def test_context_should_not_contain_deleted_objects(self):
         self.random_user.delete()
         self.notification.refresh_from_db()
-        self.assertEqual(self.notification._context, {'article': self.article, 'random_user': None})
+        self.assertEqual(self.notification.related_objects_dict, {'article': self.article, 'random_user': None})
 
     def test_creating_notification_should_not_be_possible_with_related_objects_in_invalid_format(self):
         INVALID_RELATED_OBJECTS = (

--- a/pynotify/models.py
+++ b/pynotify/models.py
@@ -142,14 +142,18 @@ class Notification(BaseModel, metaclass=NotificationMeta):
         ordering = ('-created_at',)
 
     @cached_property
-    def _context(self):
-        context = {}
+    def related_objects_dict(self):
+        """
+        Returns related objects as a dictionary where key is name of the related object and value is the object itself.
+        This dictionary is used for rendering template fields.
+        """
+        output = {}
         for obj in self.related_objects.all():
-            context[obj.name] = obj.content_object
-        return context
+            output[obj.name] = obj.content_object
+        return output
 
     def _render(self, field):
-        return self.template.render(field, self._context)
+        return self.template.render(field, self.related_objects_dict)
 
 
 class NotificationRelatedObject(BaseModel):

--- a/pynotify/models.py
+++ b/pynotify/models.py
@@ -73,8 +73,8 @@ class NotificationTemplate(BaseModel):
 
 class NotificationManager(models.Manager):
 
-    def create(self, recipient, template, related_objects=None):
-        notification = super().create(recipient=recipient, template=template)
+    def create(self, recipient, template, related_objects=None, **kwargs):
+        notification = super().create(recipient=recipient, template=template, **kwargs)
 
         if related_objects is not None:
             if not isinstance(related_objects, dict):


### PR DESCRIPTION
This will allow simpler creation of notifications, especially in tests.