### PR TITLE
Add _can_handle() method and PYNOTIFY_ENABLED

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,6 +15,11 @@ You can configure the library in Django settings. Following options are availabl
 
     Import path to a Celery task used in asynchronous mode. See :ref:`async`.
 
+* ``PYNOTIFY_ENABLED`` (default: ``True``)
+
+    Boolean indicating if library functionality, i.e. creating of notifications, is enabled. More specifically, if set to
+    ``False``, receiver will not be called upon signal reception.
+
 * ``PYNOTIFY_RECEIVER`` (default: ``pynotify.receivers.SynchronousReceiver``)
 
     Import path to a receiver class.

--- a/example/tests/test_handlers.py
+++ b/example/tests/test_handlers.py
@@ -57,6 +57,9 @@ class TestDataHandler(BaseHandler):
     def _can_dispatch_notification(self, notification, dispatcher):
         return notification.recipient.username != 'John'
 
+    def _can_handle(self):
+        return self.signal_kwargs.get('can_handle', True)
+
     class Meta:
         signal = test_signal_data
 
@@ -136,6 +139,11 @@ class HandlerTestCase(TestCase):
         test_signal_data.send(sender=None, recipients=[self.user1])
         notifications = self.user1.notifications.all()
         self.assertEqual(notifications[0].template, notifications[1].template)
+
+        # Test _can_handle() method is used
+        self.user1.notifications.all().delete()
+        test_signal_data.send(sender=None, recipients=[self.user1], can_handle=False)
+        self.assertEqual(self.user1.notifications.count(), 0)
 
     def test_handler_should_create_notification_using_template_slug(self):
         test_signal_slug.send(sender=MockSender, recipients=[self.user1])

--- a/example/tests/test_helpers.py
+++ b/example/tests/test_helpers.py
@@ -72,6 +72,13 @@ class HelpersTestCase(TestCase):
         test_signal.send(sender='abc', abc=123)
         self.assertEqual(MockHandler1.signal_kwargs, {'abc': 123})
 
+    @override_settings(PYNOTIFY_ENABLED=False)
+    def test_receive_should_not_call_handler_if_pynotify_not_enabled(self):
+        MockHandler1.signal_kwargs = 'constant'
+        register(test_signal, MockHandler1)
+        test_signal.send(sender='abc', abc=123)
+        self.assertEqual(MockHandler1.signal_kwargs, 'constant')
+
     @override_settings(PYNOTIFY_RECEIVER='pynotify.receivers.SynchronousReceiver')
     def test_receive_should_not_call_handler_if_disallowed_sender_sent_the_signal(self):
         MockHandler1.signal_kwargs = 'constant'

--- a/pynotify/config.py
+++ b/pynotify/config.py
@@ -9,6 +9,7 @@ class Settings:
     DEFAULTS = {
         'AUTOLOAD_APPS': None,
         'CELERY_TASK': 'pynotify.tasks.notification_task',
+        'ENABLED': True,
         'RECEIVER': 'pynotify.receivers.SynchronousReceiver',
         'TEMPLATE_CHECK': False,
         'TEMPLATE_TRANSLATE': False,

--- a/pynotify/helpers.py
+++ b/pynotify/helpers.py
@@ -46,6 +46,9 @@ def receive(sender, **kwargs):
     """
     Initiates processing of the signal by notification handlers through a receiver.
     """
+    if not settings.ENABLED:
+        return
+
     signal = kwargs.pop('signal')
     receiver_class = locate(settings.RECEIVER)
 


### PR DESCRIPTION
`_can_handle()` will make creating handlers more convenient... instead of creating condition in `handle()` and then calling super's method, `_can_handle()` can just return boolean expression and it nicely fits into other `_can...` methods already existing on the base handler class.

`PYNOTIFY_ENABLE` will allow easy switch off of the library functionality, if needed (for example in tests)