### PR TITLE
Add possibility to dynamically override handler attributes

### DIFF
--- a/example/tests/test_notify.py
+++ b/example/tests/test_notify.py
@@ -1,24 +1,56 @@
+from unittest.mock import MagicMock
+
 from django.contrib.auth.models import User
 from django.test import TestCase
 
+from pynotify.models import NotificationTemplate
 from pynotify.notify import notify
+
+
+class MockDispatcher:
+    dispatch = MagicMock()
 
 
 class NotifyTestCase(TestCase):
 
+    def setUp(self):
+        self.template = NotificationTemplate.objects.create(title='Hi!', slug='my-template')
+        self.user = User.objects.create_user('John')
+
     def test_notify_should_create_notification(self):
-        user = User.objects.create_user('John')
         notify(
-            recipients=[user],
+            recipients=[self.user],
             title='{{greeting}} {{user}}!',
             text='Welcome to PyNotify!',
             trigger_action='http://localhost/',
-            related_objects={'user': user},
+            related_objects={'user': self.user},
             extra_data={'greeting': 'Hello'},
+            dispatcher_classes=(MockDispatcher,)
         )
 
-        notification = user.notifications.get()
+        notification = self.user.notifications.get()
 
         self.assertEqual(notification.title, 'Hello John!')
         self.assertEqual(notification.text, 'Welcome to PyNotify!')
         self.assertEqual(notification.trigger_action, 'http://localhost/')
+        MockDispatcher.dispatch.assert_called_once_with(notification)
+
+    def test_notify_should_create_notification_from_existing_template(self):
+        notify(
+            recipients=[self.user],
+            template_slug='my-template'
+        )
+
+        notification = self.user.notifications.get()
+        self.assertEqual(notification.title, 'Hi!')
+
+    def test_notify_should_accept_either_template_data_or_template_slug(self):
+        with self.assertRaises(ValueError):
+            notify(
+                recipients=[self.user],
+                title='Greetings!',
+                template_slug='my-template',
+            )
+
+        with self.assertRaises(ValueError):
+            notify(recipients=[self.user])

--- a/pynotify/notify.py
+++ b/pynotify/notify.py
@@ -4,13 +4,17 @@ from .handlers import BaseHandler
 
 
 notify_signal = Signal(providing_args=['recipients', 'title', 'text', 'trigger_action', 'related_objects',
-                                       'extra_data'])
+                                       'extra_data', 'template_slug', 'dispatcher_classes'])
 
 
-def notify(recipients, title, text=None, trigger_action=None, related_objects=None, extra_data=None):
+def notify(recipients, title=None, text=None, trigger_action=None, related_objects=None, extra_data=None,
+           template_slug=None, dispatcher_classes=None):
     """
     Helper method to create a notification. Simply sends the ``notify_signal``.
     """
+    if bool(template_slug) == (bool(title) | bool(text) | bool(trigger_action)):
+        raise ValueError('Either provide template slug or template data, not both.')
+
     notify_signal.send(
         sender=None,
         recipients=recipients,
@@ -19,6 +23,8 @@ def notify(recipients, title, text=None, trigger_action=None, related_objects=No
         trigger_action=trigger_action,
         related_objects=related_objects,
         extra_data=extra_data,
+        template_slug=template_slug,
+        dispatcher_classes=dispatcher_classes,
     )
 
 
@@ -37,6 +43,12 @@ class NotifyHandler(BaseHandler):
 
     def get_extra_data(self):
         return self.signal_kwargs['extra_data']
+
+    def get_template_slug(self):
+        return self.signal_kwargs['template_slug']
+
+    def get_dispatcher_classes(self):
+        return self.signal_kwargs['dispatcher_classes']
 
     class Meta:
         signal = notify_signal


### PR DESCRIPTION
`BaseHandler` now has following attributes, that cannot be easily dynamically changed, because they are accessed directly:
- `template_slug`
-  `dispatcher_classes`

This PR adds methods that return these values, so they can be easily dynamically overriden in child handlers (e.g. depending on received signal kwargs).