### PR TITLE
Allow arbitrary module to contain notification handlers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ not released yet
 ----------------
 
 * Fix documentation
+* Change ``PYNOTIFY_AUTOLOAD_APPS`` to ``PYNOTIFY_AUTOLOAD_MODULES``, i.e. allow notification handlers to reside in
+  arbitrary module
 
 0.2.2 (2020-02-11)
 ------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6,10 +6,11 @@ Configuration
 
 You can configure the library in Django settings. Following options are available:
 
-* ``PYNOTIFY_AUTOLOAD_APPS`` (default: ``None``)
+* ``PYNOTIFY_AUTOLOAD_MODULES`` (default: ``None``)
 
-    Iterable of Django apps that will be scanned for ``handlers`` module at startup. If the module is found, it will be
-    imported, i.e. causing notification handlers to be automatically loaded.
+    Iterable of Python modules that contain notification handlers. These modules will be imported at startup, i.e.
+    causing notification handlers to be automatically registered. For example, if you have Django app ``notifications``
+    with handlers stored in ``handlers.py``, the module for autoload will be ``notifications.handlers``.
 
 * ``PYNOTIFY_CELERY_TASK`` (default: ``pynotify.tasks.notification_task``)
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -83,9 +83,9 @@ All handlers are typically kept in file ``handlers.py`` in a dedicated applicati
 defined (or more specifically, imported), it is paired with the signal defined in handler's ``Meta``.
 
 Let's say you created ``notifications`` app with ``notifications/handlers.py``. In order for handlers to be
-automatically loaded, you must either set the ``PYNOTIFY_AUTOLOAD_APPS`` in project settings::
+automatically loaded, you must either set the ``PYNOTIFY_AUTOLOAD_MODULES`` in project settings::
 
-    PYNOTIFY_AUTOLOAD_APPS = ('notifications',)
+    PYNOTIFY_AUTOLOAD_MODULES = ('notifications.handlers',)
 
 or load handlers module manually when Django is ready, i.e. put following code to ``notifications/apps.py``::
 

--- a/example/config/settings.py
+++ b/example/config/settings.py
@@ -91,7 +91,7 @@ LOCALE_PATHS = [
     'locale',
 ]
 
-PYNOTIFY_AUTOLOAD_APPS = ('notifications',)
+PYNOTIFY_AUTOLOAD_MODULES = ('notifications.handlers',)
 
 # Uncomment following options to try asynchronous operation
 

--- a/example/tests/test_helpers.py
+++ b/example/tests/test_helpers.py
@@ -110,7 +110,7 @@ class HelpersTestCase(TestCase):
     def test_get_import_path_should_return_import_path_of_the_class(self):
         self.assertEqual(get_import_path(MockHandler1), 'example.tests.test_helpers.MockHandler1')
 
-    @override_settings(PYNOTIFY_AUTOLOAD_APPS=('example.tests.test_app',))
+    @override_settings(PYNOTIFY_AUTOLOAD_MODULES=('example.tests.test_app.handlers',))
     def test_handlers_should_be_autoloaded_from_specified_apps(self):
         self.assertEqual(signal_map.get(autoload_signal), [])
         autoload()
@@ -121,7 +121,7 @@ class HelpersTestCase(TestCase):
         self.assertEqual(handler, AutoloadHandler)
         signal_map.remove(autoload_signal)
 
-    @override_settings(PYNOTIFY_AUTOLOAD_APPS=('example.tests.test_app2',))
+    @override_settings(PYNOTIFY_AUTOLOAD_MODULES=('example.tests.test_app2.handlers',))
     def test_if_autoload_fails_it_should_be_logged(self):
         with patch('pynotify.helpers.logger') as logger:
             autoload()

--- a/pynotify/config.py
+++ b/pynotify/config.py
@@ -7,7 +7,7 @@ class Settings:
     """
     PREFIX = 'PYNOTIFY'
     DEFAULTS = {
-        'AUTOLOAD_APPS': None,
+        'AUTOLOAD_MODULES': None,
         'CELERY_TASK': 'pynotify.tasks.notification_task',
         'ENABLED': True,
         'RECEIVER': 'pynotify.receivers.SynchronousReceiver',

--- a/pynotify/helpers.py
+++ b/pynotify/helpers.py
@@ -95,15 +95,15 @@ def receive(sender, **kwargs):
 
 def autoload():
     """
-    Attempts to load (import) notification handlers from apps defined in ``PYNOTIFY_AUTOLOAD_APPS``
+    Attempts to load (import) notification handlers from modules defined in ``PYNOTIFY_AUTOLOAD_MODULES``
     """
-    apps = settings.AUTOLOAD_APPS
-    if apps:
-        for app in apps:
+    modules = settings.AUTOLOAD_MODULES
+    if modules:
+        for module in modules:
             try:
-                import_module('{}.handlers'.format(app))
+                import_module(module)
             except ImportError:
-                logger.exception('Failed to autoload notification handlers from app {}'.format(app))
+                logger.exception('Failed to autoload notification handlers from module {}'.format(module))
 
 
 def process_task(handler_class, serializer_class, signal_kwargs):


### PR DESCRIPTION
This PR allows to have notification handlers in arbitrary module. Previously, it was enforced that modules must reside in `handlers.py`, which was not always convenient, especially when other types of "handlers" were used in the same project.