### PR TITLE
Allow HTML to be stripped off notification

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+not released yet
+----------------
+
+* Add ``PYNOTIFY_STRIP_HTML`` config option
+
 0.4.0 (2020-08-12)
 ------------------
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,6 +29,10 @@ You can configure the library in Django settings. Following options are availabl
 
     A set of related object's attributes that can be used in notification template(s).
 
+* ``PYNOTIFY_STRIP_HTML`` (default: ``False``)
+
+    If set to ``True``, HTML tags and entities will be stripped off during notification rendering.
+
 * ``PYNOTIFY_TEMPLATE_CHECK`` (default: ``False``)
 
     Boolean indicating if template string should be checked before rendering. If any named related object or extra data

--- a/pynotify/config.py
+++ b/pynotify/config.py
@@ -12,6 +12,7 @@ class Settings:
         'ENABLED': True,
         'RECEIVER': 'pynotify.receivers.SynchronousReceiver',
         'RELATED_OBJECTS_ALLOWED_ATTRIBUTES': {'get_absolute_url', },
+        'STRIP_HTML': False,
         'TEMPLATE_CHECK': False,
         'TEMPLATE_PREFIX': '',
         'TEMPLATE_TRANSLATE': False,

--- a/pynotify/helpers.py
+++ b/pynotify/helpers.py
@@ -2,6 +2,7 @@ from importlib import import_module
 import logging
 from pydoc import locate
 
+from bs4 import BeautifulSoup
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext as _
 
@@ -151,3 +152,10 @@ def get_from_context(variable, context):
             return None
 
     return value
+
+
+def strip_html(value):
+    """
+    Strips HTML (tags and entities) from string `value`.
+    """
+    return BeautifulSoup(value, 'lxml').get_text()

--- a/pynotify/models.py
+++ b/pynotify/models.py
@@ -14,7 +14,7 @@ from django.utils.translation import ugettext_lazy as _l
 
 from .config import settings
 from .exceptions import MissingContextVariableError
-from .helpers import DeletedRelatedObject, SecureRelatedObject, get_from_context
+from .helpers import DeletedRelatedObject, SecureRelatedObject, get_from_context, strip_html
 
 
 class BaseModel(SmartModel):
@@ -113,7 +113,12 @@ class NotificationTemplate(BaseTemplate):
                 if value is None or isinstance(value, DeletedRelatedObject):
                     raise MissingContextVariableError(field, var)
 
-        return Template('{}{}'.format(settings.TEMPLATE_PREFIX, template_string)).render(Context(context))
+        output = Template('{}{}'.format(settings.TEMPLATE_PREFIX, template_string)).render(Context(context))
+
+        if settings.STRIP_HTML:
+            output = strip_html(output)
+
+        return output
 
 
 class NotificationQuerySet(SmartQuerySet):

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,11 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
+    'beautifulsoup4 ~=4.8.0',
+    'celery >= 4.2.0',
     'django >= 2.2',
     'django-chamber ~= 0.5.0',
-    'celery >= 4.2.0',
+    'lxml ~= 4.5.0',
 ]
 
 setup(


### PR DESCRIPTION
Some systems cannot interpret HTML, so this PR adds possibility to strip off HTML from notification, by introducing a new setting `PYNOTIFY_STRIP_HTML`. 

Since we are using HTML-based template engine, we are unable to guarantee HTML-free values on input (because rendering of context is out of out control), therefore we must strip HTML on output. This has also advantage, that this setting can be switched on and off freely without the need to modify existing (admin) templates.